### PR TITLE
refactor: 주문 스케줄러 리팩토링

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-*.java @pushedrumex @funnysunny08 @seongHyun-Min @Seongju-Lee @bjo6300 @hseong3243

--- a/src/main/java/com/prgrms/nabmart/domain/order/service/OrderCancelService.java
+++ b/src/main/java/com/prgrms/nabmart/domain/order/service/OrderCancelService.java
@@ -1,0 +1,26 @@
+package com.prgrms.nabmart.domain.order.service;
+
+import com.prgrms.nabmart.domain.item.repository.ItemRepository;
+import com.prgrms.nabmart.domain.order.Order;
+import com.prgrms.nabmart.domain.order.OrderStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class OrderCancelService {
+
+    private final ItemRepository itemRepository;
+
+    @Transactional
+    public void cancelOrder(Order order) {
+        order.updateOrderStatus(OrderStatus.CANCELED);
+        order.unUseCoupon();
+        order.getOrderItems().forEach(
+            orderItem -> itemRepository.increaseQuantity(orderItem.getItem().getItemId(),
+                orderItem.getQuantity())
+        );
+    }
+
+}

--- a/src/main/java/com/prgrms/nabmart/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/prgrms/nabmart/domain/payment/service/PaymentService.java
@@ -3,6 +3,7 @@ package com.prgrms.nabmart.domain.payment.service;
 import com.prgrms.nabmart.domain.order.Order;
 import com.prgrms.nabmart.domain.order.OrderStatus;
 import com.prgrms.nabmart.domain.order.exception.NotPayingOrderException;
+import com.prgrms.nabmart.domain.order.service.OrderCancelService;
 import com.prgrms.nabmart.domain.order.service.OrderService;
 import com.prgrms.nabmart.domain.payment.Payment;
 import com.prgrms.nabmart.domain.payment.PaymentStatus;
@@ -23,6 +24,7 @@ public class PaymentService {
 
     private final PaymentRepository paymentRepository;
     private final OrderService orderService;
+    private final OrderCancelService orderCancelService;
 
     @Value("${payment.toss.success-url}")
     private String successCallBackUrl;
@@ -134,7 +136,7 @@ public class PaymentService {
         Order order = getOrderByUuidAndUserId(uuid, userId);
         validateOrderStatusWithPaying(order);
 
-        orderService.cancelOrder(order);
+        orderCancelService.cancelOrder(order);
 
         return new PaymentResponse(payment.getPaymentStatus().toString(), errorMessage);
     }

--- a/src/test/java/com/prgrms/nabmart/domain/order/service/OrderCancelServiceTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/order/service/OrderCancelServiceTest.java
@@ -1,0 +1,51 @@
+package com.prgrms.nabmart.domain.order.service;
+
+import static com.prgrms.nabmart.domain.order.support.OrderFixture.pendingOrder;
+import static com.prgrms.nabmart.domain.user.support.UserFixture.user;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.prgrms.nabmart.domain.item.repository.ItemRepository;
+import com.prgrms.nabmart.domain.order.Order;
+import com.prgrms.nabmart.domain.order.OrderItem;
+import com.prgrms.nabmart.domain.order.OrderStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OrderCancelServiceTest {
+
+    @InjectMocks
+    OrderCancelService orderCancelService;
+
+    @Mock
+    ItemRepository itemRepository;
+
+    @Nested
+    @DisplayName("cancelOrder 메서드 실행 시")
+    class CancelOrderTest {
+
+        @Test
+        @DisplayName("성공")
+        void success() {
+            // given
+            Order order = pendingOrder(1L, user());
+            OrderItem orderItem = order.getOrderItems().get(0);
+
+            // when
+            orderCancelService.cancelOrder(order);
+
+            // then
+            assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELED);
+            verify(itemRepository, times(1)).increaseQuantity(orderItem.getItem().getItemId(),
+                orderItem.getQuantity());
+        }
+    }
+
+}

--- a/src/test/java/com/prgrms/nabmart/domain/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/payment/service/PaymentServiceTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.when;
 import com.prgrms.nabmart.domain.coupon.exception.InvalidUsedCouponException;
 import com.prgrms.nabmart.domain.order.Order;
 import com.prgrms.nabmart.domain.order.exception.NotPayingOrderException;
+import com.prgrms.nabmart.domain.order.service.OrderCancelService;
 import com.prgrms.nabmart.domain.order.service.OrderService;
 import com.prgrms.nabmart.domain.payment.Payment;
 import com.prgrms.nabmart.domain.payment.PaymentStatus;
@@ -50,6 +51,9 @@ class PaymentServiceTest {
 
     @Mock
     OrderService orderService;
+
+    @Mock
+    OrderCancelService orderCancelService;
 
     @Value("${payment.toss.success_url}")
     private String successCallBackUrl;
@@ -288,7 +292,7 @@ class PaymentServiceTest {
             assertThat(payment.getPaymentStatus()).isEqualTo(PaymentStatus.FAILED);
             assertThat(result).usingRecursiveComparison().isEqualTo(expected);
 
-            verify(orderService, times(1)).cancelOrder(order);
+            verify(orderCancelService, times(1)).cancelOrder(order);
 
         }
     }


### PR DESCRIPTION
### ⛏ 작업 사항
- 주문 스케줄러 리팩토링

### 📝 작업 요약
- 재고 복구 로직에서 발생하는 갱신 손실을 원자적 쿼리를 사용하여 해결
- 주문을 취소 트랜잭션을 물리적으로 분리

### 💡 관련 이슈

